### PR TITLE
Add AWS profile option

### DIFF
--- a/aws-cdk/Makefile
+++ b/aws-cdk/Makefile
@@ -7,6 +7,7 @@
 # Using 'sh -c' can avoid situation then VCS do not preserves file permissions
 sh_c := sh -c
 
+# Use default value for aws_profile variable if it's not defined
 ifndef aws_profile
   aws_profile=default
 endif

--- a/aws-cdk/Makefile
+++ b/aws-cdk/Makefile
@@ -7,6 +7,10 @@
 # Using 'sh -c' can avoid situation then VCS do not preserves file permissions
 sh_c := sh -c
 
+ifndef aws_profile
+  aws_profile=default
+endif
+
 .PHONY: help
 help: ## Print this help
 	@echo "List of available commands:"
@@ -18,7 +22,7 @@ aws-cdk: ## Install AWS CDK
 
 .PHONY: bootstrap-cdk
 bootstrap-cdk: ## Bootstrapping AWS CDK environment
-	$(sh_c) 'cdk bootstrap'
+	$(sh_c) 'cdk bootstrap --profile ${aws_profile}'
 
 .PHONY: init-cdk-app
 init-cdk-app: ## Initialize AWS CDK Java application
@@ -33,8 +37,4 @@ build: ## Build App Stack
 
 .PHONY: deploy
 deploy: build ## Deploy App Stack
-	$(sh_c) 'cdk deploy'
-
-.PHONY: destroy
-destroy:  ## Destroy App Stack
-	$(sh_c) 'cdk destroy'
+	$(sh_c) 'cdk deploy --profile ${aws_profile}'

--- a/aws-cdk/README.md
+++ b/aws-cdk/README.md
@@ -16,6 +16,13 @@ git remote add origin https://github.com/<ACCOUNT>/<NAME>.git
 git branch -M main
 ````
 Then open project in IntelliJ IDEA and `push` changes to remote
+````
+make deploy
+````
+or
+````
+make deploy aws_profile=<AWS_PROFILE>
+````
 
 Run `make` or `make help` to list available commands.
 

--- a/aws-cdk/README.md
+++ b/aws-cdk/README.md
@@ -17,6 +17,8 @@ git branch -M main
 ````
 Then open project in IntelliJ IDEA and `push` changes to remote
 
+Run `make` or `make help` to list available commands.
+
 ### Further reading
 - [AWS CDK Reference Documentation](https://docs.aws.amazon.com/cdk/api/v2/)
 - [AWS CDK Java Examples](https://github.com/aws-samples/aws-cdk-examples/tree/master/java)


### PR DESCRIPTION
This PR adds AWS profile option to run `bootstrap-cdk` and `deploy` Makefile targets.

`make bootstrap-cdk aws_profile=<AWS_PROFILE>`
`make deploy aws_profile=<AWS_PROFILE>`

The `default` profile will be used if AWS profile option is not mentioned.
`make bootstrap-cdk`
`make deploy`
